### PR TITLE
Add a script to keep all extensions dependency versions in line

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+package_flag=''
+version_flag=''
+while getopts 'p:v:' flag; do
+case "${flag}" in
+    p) package_flag="${OPTARG}" ;;
+    v) version_flag="${OPTARG}" ;;
+  esac
+done
+export PKG=$package_flag
+export VERS=$version_flag
+echo "Ok, going to update all extension-examples to ${PKG}@${VERS}... Cancel this command within 5 seconds if you don't want to do this!"
+sleep 5
+echo "Updating!"
+find . -type d -not -path '*/node_modules*' \
+-exec sh -c 'shopt -s failglob; ( : "$1"/*.lock ) 2>/dev/null && cd {} && yarn add "${PKG}@${VERS}"' - {} \;
+


### PR DESCRIPTION
`update.sh` can be used to loop through every extension in the repository and update a specified package to a specified version.

**Example usage from root of repo"** 
```
./update.sh -p @looker/sdk -v 21.0.7
```
This would update the package (-p) @looker/sdk to version (-v) 21.0.7 **across all extensions.** I think that last bit is desirable because it makes things uniform, but if that's not the case I can add in some selection criteria.

I thought about making it fast by just editing the text of package.json, but I think it is useful to actually run the yarn add command to make sure the version exists, see if there are errors, etc. (not to mention prep the extensions to actually be tested). It takes ~240s to run across the repo in its current state.

I imagine the flow to do updates will be something like 
```
git clone git@github.com:looker-open-source/extension-examples.git
cd extension-examples
git checkout -b izzy/bump-looker-sdk-2107
./update.sh -p @looker/sdk -v 21.0.7
git add .
git commit -m "bumped @looker/sdk to 21.0.7"
git push
```

idk how to bash so if this short script in fact raises the dead please let me know.