### PR TITLE
Embed demo improvements

### DIFF
--- a/react/javascript/demo-embeds/manifest.lkml
+++ b/react/javascript/demo-embeds/manifest.lkml
@@ -16,7 +16,7 @@ application: demo-embeds {
     use_downloads: no
     use_iframes: no
     use_clipboard: no
-    core_api_methods: ["search_dashboards", "search_looks", "all_lookml_models"]
+    core_api_methods: ["all_lookml_models", "all_dashboards", "all_looks"]
     external_api_urls: []
     oauth2_urls: []
     scoped_user_attributes: []

--- a/react/javascript/demo-embeds/src/components/ExploresEmbed/ExploresEmbed.jsx
+++ b/react/javascript/demo-embeds/src/components/ExploresEmbed/ExploresEmbed.jsx
@@ -37,7 +37,7 @@ import {
 import { ExtensionContext2 } from '@looker/extension-sdk-react'
 import { LookerEmbedSDK } from '@looker/embed-sdk'
 import {
-  useSearchExplores,
+  useAllExplores,
   useCurrentRoute,
   useNavigate,
   useListenEmbedEvents,
@@ -48,17 +48,19 @@ import { EmbedContainer } from '../EmbedContainer'
 import { EmbedEvents } from '../EmbedEvents'
 
 export const ExploresEmbed = ({ embedType }) => {
-  const { searchCriteria, embedId } = useCurrentRoute(embedType)
-  const { updateSearchCriteria, updateEmbedId } = useNavigate(embedType)
+  const { embedId } = useCurrentRoute(embedType)
+  const { updateEmbedId } = useNavigate(embedType)
   const { extensionSDK } = useContext(ExtensionContext2)
-  const [criteria, setCriteria] = useState(searchCriteria || '')
   const [message, setMessage] = useState()
   const [running, setRunning] = useState()
   const [exploreId, setExploreId] = useState()
   const [explore, setExplore] = useState()
-  const { data, isLoading, error } = useSearchExplores(criteria, embedType)
-  const results = data
   const { embedEvents, listenEmbedEvents } = useListenEmbedEvents()
+  const { data, isLoading, error } = useAllExplores()
+  const results = (data || []).map(({ id, title }) => ({
+    id,
+    description: title,
+  }))
 
   useEffect(() => {
     if (exploreId !== embedId) {
@@ -112,11 +114,6 @@ export const ExploresEmbed = ({ embedType }) => {
     [exploreId]
   )
 
-  const onSearch = (criteria) => {
-    setCriteria(criteria)
-    updateSearchCriteria(criteria)
-  }
-
   const onSelected = (id) => {
     if (id !== exploreId) {
       // updateRunButton(true)
@@ -147,13 +144,11 @@ export const ExploresEmbed = ({ embedType }) => {
         <Aside width="25%" height="100%" pr="small">
           <SpaceVertical height="100%">
             <Search
-              onSearch={onSearch}
               onSelected={onSelected}
               loading={isLoading}
               error={error}
               data={results}
               embedRunning={running}
-              searchCriteria={searchCriteria}
             />
             <EmbedEvents events={embedEvents} />
           </SpaceVertical>

--- a/react/javascript/demo-embeds/src/components/LooksEmbed/LooksEmbed.jsx
+++ b/react/javascript/demo-embeds/src/components/LooksEmbed/LooksEmbed.jsx
@@ -37,26 +37,24 @@ import {
 import { ExtensionContext2 } from '@looker/extension-sdk-react'
 import { LookerEmbedSDK } from '@looker/embed-sdk'
 import {
-  useSearchLooks,
+  useAllLooks,
   useCurrentRoute,
   useNavigate,
   useListenEmbedEvents,
 } from '../../hooks'
-
 import { Search } from '../Search'
 import { EmbedContainer } from '../EmbedContainer'
 import { EmbedEvents } from '../EmbedEvents'
 
 export const LooksEmbed = ({ embedType }) => {
-  const { searchCriteria, embedId } = useCurrentRoute(embedType)
-  const { updateSearchCriteria, updateEmbedId } = useNavigate(embedType)
+  const { embedId } = useCurrentRoute(embedType)
+  const { updateEmbedId } = useNavigate(embedType)
   const { extensionSDK } = useContext(ExtensionContext2)
-  const [criteria, setCriteria] = useState(searchCriteria || '')
   const [message, setMessage] = useState()
   const [running, setRunning] = useState()
   const [lookId, setLookId] = useState()
   const [look, setLook] = useState()
-  const { data, isLoading, error } = useSearchLooks(criteria, embedType)
+  const { data, isLoading, error } = useAllLooks()
   const results = (data || []).map(({ id, title }) => ({
     id,
     description: title,
@@ -115,11 +113,6 @@ export const LooksEmbed = ({ embedType }) => {
     [lookId]
   )
 
-  const onSearch = (criteria) => {
-    setCriteria(criteria)
-    updateSearchCriteria(criteria)
-  }
-
   const onSelected = (id) => {
     if (id !== lookId) {
       setLookId(id)
@@ -149,13 +142,11 @@ export const LooksEmbed = ({ embedType }) => {
         <Aside width="25%" height="100%" pr="small">
           <SpaceVertical height="100%">
             <Search
-              onSearch={onSearch}
               onSelected={onSelected}
               loading={isLoading}
               error={error}
               data={results}
               embedRunning={running}
-              searchCriteria={searchCriteria}
             />
             <EmbedEvents events={embedEvents} />
           </SpaceVertical>

--- a/react/javascript/demo-embeds/src/components/Search/Search.jsx
+++ b/react/javascript/demo-embeds/src/components/Search/Search.jsx
@@ -30,66 +30,45 @@ import {
   Space,
   List,
   ListItem,
-  Form,
   FieldText,
-  IconButton,
-  Spinner,
 } from '@looker/components'
-import { Search as SearchIcon } from '@styled-icons/material'
+import { useNavigate } from '../../hooks'
 
 export const Search = ({
-  onSearch,
   onSelected,
   data = [],
   error,
   loading,
   embedRunning,
-  searchCriteria,
+  embedType,
 }) => {
   const [criteria, setCriteria] = useState('')
+  const { updateSearchCriteria } = useNavigate(embedType)
 
   useEffect(() => {
-    setCriteria(searchCriteria || '')
-    if (
-      searchCriteria &&
-      searchCriteria.length > 0 &&
-      searchCriteria !== criteria
-    ) {
-      onSearch(searchCriteria)
-    }
-  }, [searchCriteria])
+    updateSearchCriteria(criteria)
+  }, [criteria])
 
-  const onSubmit = (e) => {
-    e.preventDefault()
-    onSearch(criteria.trim())
-  }
+  const selectedData =
+    criteria.length === 0
+      ? data
+      : data.filter(({ description }) =>
+          description.toLowerCase().includes(criteria.trim().toLowerCase())
+        )
 
   return (
     <Box height="33%" width="100%" borderBottom="solid 1px" borderColor="ui2">
-      <Form onSubmit={onSubmit} mb="none">
-        <Space px="small">
-          {error && <MessageBar intent="critical">{error}</MessageBar>}
-          <FieldText
-            placeholder="Enter search criteria"
-            value={criteria}
-            onChange={(e) => setCriteria(e.target.value)}
-            disabled={loading}
-          />
-          {loading ? (
-            <Spinner />
-          ) : (
-            <IconButton
-              type="submit"
-              size="large"
-              label="Search"
-              disabled={criteria.trim().length === 0}
-              icon={<SearchIcon />}
-            />
-          )}
-        </Space>
-      </Form>
+      <Space px="small">
+        {error && <MessageBar intent="critical">{error}</MessageBar>}
+        <FieldText
+          placeholder="Enter search criteria"
+          value={criteria}
+          onChange={(e) => setCriteria(e.target.value)}
+          disabled={loading}
+        />
+      </Space>
       <List mt="none" density={-2} height="85%">
-        {data.map(({ description, id }) => (
+        {selectedData.map(({ description, id }) => (
           <ListItem
             key={id}
             onClick={() => onSelected(id)}
@@ -104,11 +83,10 @@ export const Search = ({
 }
 
 Search.propTypes = {
-  searchCriteria: PropTypes.string,
-  onSearch: PropTypes.func.isRequired,
   onSelected: PropTypes.func.isRequired,
   data: PropTypes.array,
   error: PropTypes.string,
   loading: PropTypes.bool,
   embedRunning: PropTypes.bool,
+  embedType: PropTypes.string,
 }

--- a/react/javascript/demo-embeds/src/hooks/use_all_dashboards.jsx
+++ b/react/javascript/demo-embeds/src/hooks/use_all_dashboards.jsx
@@ -24,33 +24,22 @@
 import { useContext } from 'react'
 import { useQuery } from 'react-query'
 import { ExtensionContext2 } from '@looker/extension-sdk-react'
+import { sortByTitle } from './utils'
 
-const search = async (coreSDK, criteria) => {
+const all = async (coreSDK) => {
   try {
-    const data = await coreSDK.ok(coreSDK.all_lookml_models())
-    const models = data.filter((lookml) => lookml.explores.length > 0)
-    const explores = []
-    models.forEach((model) => {
-      model.explores.forEach((explore) => {
-        if (!explore.hidden) {
-          const id = `${model.name}::${explore.name}`
-          explores.push({ description: id, id })
-        }
-      })
-    })
-    return explores.filter((explore) => explore.id.includes(criteria))
+    const data = await coreSDK.ok(coreSDK.all_dashboards())
+    data.sort(sortByTitle)
+    return data
   } catch (err) {
-    throw new Error('Error searching looks')
+    throw new Error('Error retrieving dashboards')
   }
 }
 
-export const useSearchExplores = (criteria = '', embedType) => {
+export const useAllDashboards = () => {
   const { coreSDK } = useContext(ExtensionContext2)
-  return useQuery(
-    [`search_explores_${embedType}`, criteria],
-    () => search(coreSDK, criteria),
-    {
-      enabled: criteria.trim().length > 0,
-    }
-  )
+  return useQuery(['all_dashboards'], () => all(coreSDK), {
+    enabled: true,
+    staleTime: Infinity,
+  })
 }

--- a/react/javascript/demo-embeds/src/hooks/use_all_looks.jsx
+++ b/react/javascript/demo-embeds/src/hooks/use_all_looks.jsx
@@ -21,32 +21,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 import { useContext } from 'react'
 import { useQuery } from 'react-query'
 import { ExtensionContext2 } from '@looker/extension-sdk-react'
+import { sortByTitle } from './utils'
 
-const search = async (coreSDK, criteria) => {
+const all = async (coreSDK) => {
   try {
-    const data = await coreSDK.ok(
-      coreSDK.search_dashboards({
-        title: `%${criteria}%`,
-        description: `%${criteria}%`,
-        filter_or: true,
-      })
-    )
+    const data = await coreSDK.ok(coreSDK.all_looks())
+    data.sort(sortByTitle)
     return data
   } catch (err) {
-    throw new Error('Error searching dashboards')
+    throw new Error('Error retrieving looks')
   }
 }
 
-export const useSearchDashboards = (criteria = '', embedType) => {
+export const useAllLooks = () => {
   const { coreSDK } = useContext(ExtensionContext2)
-  return useQuery(
-    [`search_dashboard_${embedType}`, criteria],
-    () => search(coreSDK, criteria),
-    {
-      enabled: criteria.trim().length > 0,
-    }
-  )
+  return useQuery(['all_looks'], () => all(coreSDK), {
+    enabled: true,
+    staleTime: Infinity,
+  })
 }

--- a/react/javascript/demo-embeds/src/hooks/use_listen_embed_events.jsx
+++ b/react/javascript/demo-embeds/src/hooks/use_listen_embed_events.jsx
@@ -59,7 +59,10 @@ export const useListenEmbedEvents = () => {
       'page:properties:changed',
     ]
     eventTypes.forEach((type) =>
-      embed.on(type, (e) => setEmbedEvents([e, ...embedEventsRef.current]))
+      embed.on(type, (e) => {
+        setEmbedEvents([e, ...embedEventsRef.current])
+        return {}
+      })
     )
   }
 

--- a/react/javascript/demo-embeds/src/hooks/utils/index.js
+++ b/react/javascript/demo-embeds/src/hooks/utils/index.js
@@ -21,9 +21,5 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-export * from './use_current_route'
-export * from './use_navigate'
-export * from './use_all_dashboards'
-export * from './use_all_looks'
-export * from './use_all_explores'
-export * from './use_listen_embed_events'
+
+export * from './sort_by_title'

--- a/react/javascript/demo-embeds/src/hooks/utils/sort_by_title.js
+++ b/react/javascript/demo-embeds/src/hooks/utils/sort_by_title.js
@@ -21,32 +21,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-import { useContext } from 'react'
-import { useQuery } from 'react-query'
-import { ExtensionContext2 } from '@looker/extension-sdk-react'
 
-const search = async (coreSDK, criteria) => {
-  try {
-    const data = await coreSDK.ok(
-      coreSDK.search_looks({
-        title: `%${criteria}%`,
-        description: `%${criteria}%`,
-        filter_or: true,
-      })
-    )
-    return data
-  } catch (err) {
-    throw new Error('Error searching looks')
+export const sortByTitle = (a, b) => {
+  if (a.title.toLowerCase() < b.title.toLowerCase()) {
+    return -1
   }
-}
-
-export const useSearchLooks = (criteria = '', embedType) => {
-  const { coreSDK } = useContext(ExtensionContext2)
-  return useQuery(
-    [`search_looks_${embedType}`, criteria],
-    () => search(coreSDK, criteria),
-    {
-      enabled: criteria.trim().length > 0,
-    }
-  )
+  if (a.title.toLowerCase() > b.title.toLowerCase()) {
+    return 1
+  }
+  return 0
 }


### PR DESCRIPTION
1. Search revamped to auto load dashboards, looks and explores on tab activation. Call to search_xxx replaced with call to all_xxx. Search is now an in memory search.
2. Added toggle to dashboards and dashboards legacy to control behavior of cancel for some embed events. Also fixed an issue that became apparent after cancel NOT applied. Cancellable embed events should ALWAYs return an object for legacy dashboards.
3. Added a button on legacy dashboards to unlock search tile. For some reason, dashboards legacy not firing end events when there is a catastrophic failure of the dashboard. This will be looked into separately. Clicking the button allows the user to pick another dashboard to load.