### PR TITLE
fix: Looker Components Popover positioning

### DIFF
--- a/react/javascript/demo-core-sdk/src/index.jsx
+++ b/react/javascript/demo-core-sdk/src/index.jsx
@@ -30,6 +30,7 @@ import { App } from './App'
 
 window.addEventListener('DOMContentLoaded', (event) => {
   const root = document.createElement('div')
+  root.style.height = '100%'
   document.body.appendChild(root)
   ReactDOM.render(<App />, root)
 })

--- a/react/javascript/demo-embeds/src/index.js
+++ b/react/javascript/demo-embeds/src/index.js
@@ -30,6 +30,7 @@ import { App } from './App'
 
 window.addEventListener('DOMContentLoaded', (event) => {
   const root = document.createElement('div')
+  root.style.height = '100%'
   document.body.appendChild(root)
   ReactDOM.render(<App />, root)
 })

--- a/react/javascript/demo-extension-sdk/src/index.jsx
+++ b/react/javascript/demo-extension-sdk/src/index.jsx
@@ -30,6 +30,7 @@ import { App } from './App'
 
 window.addEventListener('DOMContentLoaded', (event) => {
   const root = document.createElement('div')
+  root.style.height = '100%'
   document.body.appendChild(root)
   ReactDOM.render(<App />, root)
 })

--- a/react/javascript/demo-external-api/src/index.jsx
+++ b/react/javascript/demo-external-api/src/index.jsx
@@ -30,6 +30,7 @@ import { App } from './App'
 
 window.addEventListener('DOMContentLoaded', (event) => {
   const root = document.createElement('div')
+  root.style.height = '100%'
   document.body.appendChild(root)
   ReactDOM.render(<App />, root)
 })

--- a/react/javascript/file-download/src/index.js
+++ b/react/javascript/file-download/src/index.js
@@ -30,6 +30,7 @@ import { App } from './App'
 
 window.addEventListener('DOMContentLoaded', () => {
   const root = document.createElement('div')
+  root.style.height = '100%'
   document.body.appendChild(root)
   ReactDOM.render(<App />, root)
 })

--- a/react/javascript/file-upload/src/index.js
+++ b/react/javascript/file-upload/src/index.js
@@ -30,6 +30,7 @@ import { App } from './App'
 
 window.addEventListener('DOMContentLoaded', (event) => {
   const root = document.createElement('div')
+  root.style.height = '100%'
   document.body.appendChild(root)
   ReactDOM.render(<App />, root)
 })

--- a/react/javascript/helloworld-js/src/index.js
+++ b/react/javascript/helloworld-js/src/index.js
@@ -30,6 +30,7 @@ import { App } from './App'
 
 window.addEventListener('DOMContentLoaded', (event) => {
   const root = document.createElement('div')
+  root.style.height = '100%'
   document.body.appendChild(root)
   ReactDOM.render(<App />, root)
 })

--- a/react/javascript/map-iframe/src/index.js
+++ b/react/javascript/map-iframe/src/index.js
@@ -30,6 +30,7 @@ import { App } from './App'
 
 window.addEventListener('DOMContentLoaded', (event) => {
   const root = document.createElement('div')
+  root.style.height = '100%'
   document.body.appendChild(root)
   ReactDOM.render(<App />, root)
 })

--- a/react/typescript/access-key-demo/src/index.tsx
+++ b/react/typescript/access-key-demo/src/index.tsx
@@ -30,6 +30,7 @@ import { App } from './App'
 
 window.addEventListener('DOMContentLoaded', () => {
   const root = document.createElement('div')
+  root.style.height = '100%'
   document.body.appendChild(root)
   ReactDOM.render(<App />, root)
 })

--- a/react/typescript/helloworld-ts/src/index.tsx
+++ b/react/typescript/helloworld-ts/src/index.tsx
@@ -29,6 +29,7 @@ import { App } from './App'
 
 window.addEventListener('DOMContentLoaded', (_) => {
   const root = document.createElement('div')
+  root.style.height = '100%'
   document.body.appendChild(root)
   ReactDOM.render(<App />, root)
 })

--- a/react/typescript/kitchensink/src/index.tsx
+++ b/react/typescript/kitchensink/src/index.tsx
@@ -30,6 +30,7 @@ import { App } from './App'
 
 window.addEventListener('DOMContentLoaded', () => {
   const root = document.createElement('div')
+  root.style.height = '100%'
   document.body.appendChild(root)
   ReactDOM.render(<App />, root)
 })

--- a/react/typescript/looks-query-redux/src/index.tsx
+++ b/react/typescript/looks-query-redux/src/index.tsx
@@ -34,6 +34,7 @@ import { configureStore } from './data/store'
 
 window.addEventListener('DOMContentLoaded', async () => {
   const root = document.createElement('div')
+  root.style.height = '100%'
   document.body.appendChild(root)
 
   ReactDOM.render(

--- a/react/typescript/looks-query/src/index.tsx
+++ b/react/typescript/looks-query/src/index.tsx
@@ -32,6 +32,7 @@ import { Extension } from './demo/Extension'
 
 window.addEventListener('DOMContentLoaded', async () => {
   const root = document.createElement('div')
+  root.style.height = '100%'
   document.body.appendChild(root)
 
   ReactDOM.render(

--- a/react/typescript/vis-and-filter-components/src/index.tsx
+++ b/react/typescript/vis-and-filter-components/src/index.tsx
@@ -29,6 +29,7 @@ import { App } from './App'
 
 window.addEventListener('DOMContentLoaded', (_) => {
   const root = document.createElement('div')
+  root.style.height = '100%'
   document.body.appendChild(root)
   ReactDOM.render(<App />, root)
 })


### PR DESCRIPTION
Updates the index files in each example to set the root div's height to 100% to avoid customers encountering this issue that keeps reering its head:

looker-open-source/components#2850

Internal issue ID: 240613386