### PR TITLE
feat: improve code splitting example

### DIFF
--- a/react/typescript/kitchensink/src/KitchenSink.async.tsx
+++ b/react/typescript/kitchensink/src/KitchenSink.async.tsx
@@ -24,29 +24,13 @@
 
  */
 
-import React, { useState, Suspense } from 'react'
-import { ExtensionProvider40 } from '@looker/extension-sdk-react'
-// Components loaded using code splitting
-import { AsyncKitchenSink as KitchenSink } from './KitchenSink.async'
+import React, { lazy } from 'react'
+import type { KitchenSinkProps } from './types'
 
-// If the Looker server does not support code splitting (version 7.20 and below) replace the above
-// imports with the imports below:
-// import { KitchenSink } from './KitchenSink'
+const KitchenSink = lazy<any>(
+  async () => import(/* webpackChunkName: "kitchensink" */ './KitchenSink')
+)
 
-export const App: React.FC = () => {
-  const [route, setRoute] = useState('')
-  const [routeState, setRouteState] = useState()
-
-  const onRouteChange = (route: string, routeState?: any) => {
-    setRoute(route)
-    setRouteState(routeState)
-  }
-
-  return (
-    <Suspense fallback={<></>}>
-      <ExtensionProvider40 onRouteChange={onRouteChange}>
-        <KitchenSink route={route} routeState={routeState} />
-      </ExtensionProvider40>
-    </Suspense>
-  )
-}
+export const AsyncKitchenSink: React.FC<KitchenSinkProps> = (props) => (
+  <KitchenSink {...props} />
+)

--- a/react/typescript/kitchensink/src/KitchenSink.tsx
+++ b/react/typescript/kitchensink/src/KitchenSink.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { useEffect, useState, useContext, Suspense } from 'react'
+import React, { useEffect, useState, useContext } from 'react'
 import { Switch, Route } from 'react-router-dom'
 import { intersects } from 'semver'
 import {
@@ -157,65 +157,63 @@ export const KitchenSink: React.FC<KitchenSinkProps> = ({
                 />
               </Aside>
               <Section>
-                <Suspense fallback={<></>}>
-                  <Switch>
-                    {configurationData.showApiFunctions && (
-                      <Route path={ROUTES.API_ROUTE}>
-                        <ApiFunctions />
-                      </Route>
-                    )}
-                    {configurationData.showCoreSdkFunctions && (
-                      <Route
-                        path={[
-                          ROUTES.CORESDK_ROUTE,
-                          `${ROUTES.CORESDK_ROUTE}?test=abcd`,
-                        ]}
-                      >
-                        <CoreSDKFunctions />
-                      </Route>
-                    )}
-                    {configurationData.showEmbedDashboard && (
-                      <Route path={ROUTES.EMBED_DASHBOARD}>
-                        <EmbedDashboard id={configurationData.dashboardId} />
-                      </Route>
-                    )}
-                    {configurationData.showEmbedExplore && (
-                      <Route path={ROUTES.EMBED_EXPLORE}>
-                        <EmbedExplore id={configurationData.exploreId} />
-                      </Route>
-                    )}
-                    {configurationData.showEmbedLook && (
-                      <Route path={ROUTES.EMBED_LOOK}>
-                        <EmbedLook id={configurationData.lookId} />
-                      </Route>
-                    )}
-                    {configurationData.showExternalApiFunctions && (
-                      <Route path={ROUTES.EXTERNAL_API_ROUTE}>
-                        <ExternalApiFunctions />
-                      </Route>
-                    )}
-                    {configurationData.showMiscFunctions && (
-                      <Route path={ROUTES.MISC_ROUTE}>
-                        <MiscFunctions />
-                      </Route>
-                    )}
-                    <Route path={ROUTES.CONFIG_ROUTE}>
-                      <Configure
-                        configurationData={configurationData}
-                        updateConfigurationData={updateConfigurationData}
-                        canPersistContextData={canPersistContextData}
-                      />
+                <Switch>
+                  {configurationData.showApiFunctions && (
+                    <Route path={ROUTES.API_ROUTE}>
+                      <ApiFunctions />
                     </Route>
-                    {configurationData.showMiscFunctions && (
-                      <Route path={ROUTES.MISC_ROUTE}>
-                        <MiscFunctions />
-                      </Route>
-                    )}
-                    <Route>
-                      <Home />
+                  )}
+                  {configurationData.showCoreSdkFunctions && (
+                    <Route
+                      path={[
+                        ROUTES.CORESDK_ROUTE,
+                        `${ROUTES.CORESDK_ROUTE}?test=abcd`,
+                      ]}
+                    >
+                      <CoreSDKFunctions />
                     </Route>
-                  </Switch>
-                </Suspense>
+                  )}
+                  {configurationData.showEmbedDashboard && (
+                    <Route path={ROUTES.EMBED_DASHBOARD}>
+                      <EmbedDashboard id={configurationData.dashboardId} />
+                    </Route>
+                  )}
+                  {configurationData.showEmbedExplore && (
+                    <Route path={ROUTES.EMBED_EXPLORE}>
+                      <EmbedExplore id={configurationData.exploreId} />
+                    </Route>
+                  )}
+                  {configurationData.showEmbedLook && (
+                    <Route path={ROUTES.EMBED_LOOK}>
+                      <EmbedLook id={configurationData.lookId} />
+                    </Route>
+                  )}
+                  {configurationData.showExternalApiFunctions && (
+                    <Route path={ROUTES.EXTERNAL_API_ROUTE}>
+                      <ExternalApiFunctions />
+                    </Route>
+                  )}
+                  {configurationData.showMiscFunctions && (
+                    <Route path={ROUTES.MISC_ROUTE}>
+                      <MiscFunctions />
+                    </Route>
+                  )}
+                  <Route path={ROUTES.CONFIG_ROUTE}>
+                    <Configure
+                      configurationData={configurationData}
+                      updateConfigurationData={updateConfigurationData}
+                      canPersistContextData={canPersistContextData}
+                    />
+                  </Route>
+                  {configurationData.showMiscFunctions && (
+                    <Route path={ROUTES.MISC_ROUTE}>
+                      <MiscFunctions />
+                    </Route>
+                  )}
+                  <Route>
+                    <Home />
+                  </Route>
+                </Switch>
               </Section>
             </Layout>
           </Page>
@@ -224,3 +222,5 @@ export const KitchenSink: React.FC<KitchenSinkProps> = ({
     </>
   )
 }
+
+export default KitchenSink


### PR DESCRIPTION
Updates code splitting example to reflect latest thinking. The ExtensionProvider40 is now loaded separately from the application reducing the initial bundle size from 1.1MB to 775kb. The thinking is that the ExtensionProvider should be loaded as quickly as possible so that it can communicate with the Looker host as soon as possible.